### PR TITLE
refactor: Convert startVideoTrimming notification to Combine publisher

### DIFF
--- a/LostArchiveTV/Services/VideoEditingService.swift
+++ b/LostArchiveTV/Services/VideoEditingService.swift
@@ -1,0 +1,29 @@
+//
+//  VideoEditingService.swift
+//  LostArchiveTV
+//
+//  Created by Claude on 6/26/25.
+//
+
+import Foundation
+import Combine
+import OSLog
+
+/// Service responsible for video editing functionality including trimming
+class VideoEditingService {
+    /// Publisher for video trimming events
+    static var startVideoTrimmingPublisher = PassthroughSubject<Void, Never>()
+    
+    /// Sends a start video trimming event
+    static func startVideoTrimming() async {
+        Logger.videoPlayback.info("VideoEditingService: Broadcasting start video trimming event")
+        await MainActor.run {
+            startVideoTrimmingPublisher.send()
+        }
+    }
+    
+    /// Resets publishers for testing
+    static func resetForTesting() {
+        startVideoTrimmingPublisher = PassthroughSubject<Void, Never>()
+    }
+}

--- a/LostArchiveTV/Views/Components/FavoritesVideoLayerContent.swift
+++ b/LostArchiveTV/Views/Components/FavoritesVideoLayerContent.swift
@@ -89,7 +89,9 @@ struct FavoritesVideoLayerContent: View {
                     showSettingsButton: false,
                     trimAction: {
                         // Trigger trimming to be shown in the parent view
-                        NotificationCenter.default.post(name: .startVideoTrimming, object: nil)
+                        Task {
+                            await VideoEditingService.startVideoTrimming()
+                        }
                     }
                 )
                 .padding(.trailing, 8)
@@ -101,6 +103,5 @@ struct FavoritesVideoLayerContent: View {
 
 // Notification names for video interactions
 extension Notification.Name {
-    static let startVideoTrimming = Notification.Name("startVideoTrimming")
     static let showSimilarVideos = Notification.Name("showSimilarVideos")
 }

--- a/LostArchiveTV/Views/Components/SearchVideoLayerContent.swift
+++ b/LostArchiveTV/Views/Components/SearchVideoLayerContent.swift
@@ -90,7 +90,9 @@ struct SearchVideoLayerContent: View {
                     showSettingsButton: false,
                     trimAction: {
                         // Trigger trimming to be shown in the parent view
-                        NotificationCenter.default.post(name: .startVideoTrimming, object: nil)
+                        Task {
+                            await VideoEditingService.startVideoTrimming()
+                        }
                     }
                 )
                 .padding(.trailing, 8)


### PR DESCRIPTION
## Summary
- Created VideoEditingService to manage video editing events with Combine publishers
- Replaced NotificationCenter usage for startVideoTrimming with PassthroughSubject<Void, Never>
- Updated all notification posts and observers to use the new publisher pattern

## Changes Made

### New Service
- **VideoEditingService.swift**: New service to manage video editing events
  - Static `startVideoTrimmingPublisher` for broadcasting trim events
  - `startVideoTrimming()` async method that sends events on MainActor
  - `resetForTesting()` method for test cleanup

### Updated Components
1. **SearchVideoLayerContent.swift**: 
   - Replaced `NotificationCenter.post` with `VideoEditingService.startVideoTrimming()`
   
2. **FavoritesVideoLayerContent.swift**: 
   - Replaced `NotificationCenter.post` with `VideoEditingService.startVideoTrimming()`
   - Removed `.startVideoTrimming` from Notification.Name extension

3. **PlayerViewState.swift**:
   - Added Combine import
   - Changed `trimToken` to `trimCancellable: AnyCancellable?`
   - Updated `setupTrimObserver` to subscribe to publisher
   - Updated `removeObservers` to cancel subscription

4. **VideoGestureHandler.swift**:
   - Added Combine import
   - Removed `setupNotificationObservers` method
   - Added `.onReceive` modifier to handle trim events

## Benefits
- ✅ Type-safe event handling
- ✅ Consistent with ongoing Combine migration
- ✅ Proper memory management with weak self capture
- ✅ Testable with resetForTesting method
- ✅ Follows established patterns (TransitionPreloadManager, VideoCacheService)

## Testing
The app builds successfully with no errors. The video trimming functionality continues to work as expected with the new publisher-based implementation.

🤖 Generated with [Claude Code](https://claude.ai/code)