### PR TITLE
Implement Aggressive Buffer Configuration for Enhanced Video Playback

### DIFF
--- a/LostArchiveTV/Services/VideoLoadingService.swift
+++ b/LostArchiveTV/Services/VideoLoadingService.swift
@@ -139,14 +139,17 @@ actor VideoLoadingService {
         // Create player item with format-specific caching configuration
         let playerItem = AVPlayerItem(asset: asset)
         
-        // Configure buffer size based on format
+        // Configure aggressive buffer size for all formats (5 minutes)
         if isH264IA {
-            playerItem.preferredForwardBufferDuration = 15  // Smaller buffer for optimized format
+            playerItem.preferredForwardBufferDuration = 300.0  // 5 minutes (was 15 seconds)
         } else if isH264 {
-            playerItem.preferredForwardBufferDuration = 30  // Medium buffer for h.264
+            playerItem.preferredForwardBufferDuration = 300.0  // 5 minutes (was 30 seconds)
         } else {
-            playerItem.preferredForwardBufferDuration = 60  // Larger buffer for MPEG4
+            playerItem.preferredForwardBufferDuration = 300.0  // 5 minutes (was 60 seconds)
         }
+        
+        // Remove quality limits for preloading
+        playerItem.preferredPeakBitRate = 0  // No limit (system default)
         
         // Allow network caching while paused for all formats
         playerItem.canUseNetworkResourcesForLiveStreamingWhilePaused = true
@@ -315,9 +318,27 @@ actor VideoLoadingService {
             Logger.videoPlayback.warning("Failed to preload asset keys: \(error.localizedDescription)")
             // Continue anyway - this is just an optimization
         }
+        
+        // Create player item with aggressive buffer configuration
+        let playerItem = AVPlayerItem(asset: asset)
+        
+        // Configure aggressive buffer size for all formats (5 minutes)
+        if isH264IA {
+            playerItem.preferredForwardBufferDuration = 300.0  // 5 minutes
+        } else if isH264 {
+            playerItem.preferredForwardBufferDuration = 300.0  // 5 minutes
+        } else {
+            playerItem.preferredForwardBufferDuration = 300.0  // 5 minutes
+        }
+        
+        // Remove quality limits for preloading
+        playerItem.preferredPeakBitRate = 0  // No limit (system default)
+        
+        // Allow network caching while paused for all formats
+        playerItem.canUseNetworkResourcesForLiveStreamingWhilePaused = true
         // -------------------- END: FORMAT-SPECIFIC ASSET OPTIMIZATIONS --------------------
         
-        Logger.videoPlayback.debug("Created AVURLAsset with format-specific optimizations")
+        Logger.videoPlayback.debug("Created AVURLAsset with format-specific optimizations and aggressive buffer configuration")
         
         // Set title and description from metadata
         let title = metadata.metadata?.title ?? identifier


### PR DESCRIPTION
## Summary
This PR implements aggressive buffer configuration to enhance video playback performance and reduce buffering interruptions. The changes address GitHub issue #61 by significantly increasing buffer durations and removing quality limits.

### Key Changes
- **Increased buffer durations**: Changed from conservative values (15s/30s/60s) to aggressive 300 seconds (5 minutes) for all video formats (h.264 IA, h.264, MPEG4)
- **Removed quality limits**: Set `preferredPeakBitRate = 0` to allow maximum available quality downloads
- **Consistent implementation**: Applied aggressive buffer configuration to both `loadCompleteCachedVideo` and `loadFreshRandomVideo` methods for uniform behavior
- **Enhanced background buffering**: Ensured `canUseNetworkResourcesForLiveStreamingWhilePaused = true` is set for both loading paths

### Technical Details
**File Modified**: `LostArchiveTV/Services/VideoLoadingService.swift`

**Methods Updated**:
- `loadCompleteCachedVideo` (lines 142-152): Updated existing buffer configuration to aggressive settings
- `loadFreshRandomVideo` (lines 322-338): Added aggressive buffer configuration that was previously missing

### Benefits
- **Fewer playback interruptions**: Users will experience smoother playback even on unreliable networks
- **Better support for longer videos**: Extended videos can play without mid-playback buffering pauses
- **Improved perceived performance**: Aggressive preloading creates a more seamless viewing experience
- **Network efficiency**: Bulk downloading during good connectivity reduces repeated network requests

### Test Plan
- [x] Code compiles successfully without errors or warnings
- [x] Buffer configuration applied consistently across both video loading methods
- [x] Existing functionality preserved (no breaking changes)
- [ ] Manual testing on various network conditions (WiFi, cellular, poor connectivity)
- [ ] Memory usage verification on target devices
- [ ] Regression testing for initial video load times

### Acceptance Criteria Met
- [x] Buffer duration increased to 300 seconds for all video formats
- [x] `preferredPeakBitRate` set to 0 (no limit)  
- [x] Background buffering enabled for both loading paths
- [x] No compilation errors or warnings
- [x] Existing preloading and caching mechanisms continue to function

Resolves #61

🤖 Generated with [Claude Code](https://claude.ai/code)