### PR TITLE
Fix: Make BufferingMonitor the single source of truth for buffer state

### DIFF
--- a/LostArchiveTV/Services/TransitionPreloadManager+Caching.swift
+++ b/LostArchiveTV/Services/TransitionPreloadManager+Caching.swift
@@ -46,6 +46,11 @@ extension TransitionPreloadManager {
     /// Ensures that both general video caching and transition-specific caching are performed
     /// - Parameter provider: The video provider that supplies videos
     func ensureAllVideosCached(provider: VideoProvider) async {
+        // Store weak reference to provider for buffer state queries
+        if let baseProvider = provider as? BaseVideoViewModel {
+            self.provider = baseProvider
+        }
+        
         // Include timestamp for better tracking of operations
         let startTime = CFAbsoluteTimeGetCurrent()
         Logger.caching.info("🔄 CACHING: Starting unified caching for \(String(describing: type(of: provider))) at \(startTime)")

--- a/LostArchiveTV/Services/TransitionPreloadManager+PreviousVideo.swift
+++ b/LostArchiveTV/Services/TransitionPreloadManager+PreviousVideo.swift
@@ -13,6 +13,11 @@ import Foundation
 extension TransitionPreloadManager {
     // Preload the previous video from history/sequence
     func preloadPreviousVideo(provider: VideoProvider) async {
+        // Store weak reference to provider for buffer state queries
+        if let baseProvider = provider as? BaseVideoViewModel {
+            self.provider = baseProvider
+        }
+        
         // Log timestamp when preloading starts for performance tracking
         let preloadStartTime = CFAbsoluteTimeGetCurrent()
 
@@ -89,8 +94,6 @@ extension TransitionPreloadManager {
                 // Use the BufferingMonitor's state instead of calculating our own
                 if let provider = provider as? BaseVideoViewModel {
                     await monitorPreviousVideoBufferViaMonitor(provider: provider, videoId: videoId, preloadStart: preloadStart)
-                } else {
-                    await monitorPreviousVideoBuffer(player: player, videoId: videoId, preloadStart: preloadStart)
                 }
             }
             
@@ -127,18 +130,17 @@ extension TransitionPreloadManager {
         var consecutiveReadyChecks = 0
         while !Task.isCancelled {
             // Get the buffer state from the monitor (single source of truth)
-            let bufferState = await MainActor.run {
-                provider.previousBufferingMonitor?.bufferState ?? .unknown
-            }
-            let bufferSeconds = await MainActor.run {
-                provider.previousBufferingMonitor?.bufferSeconds ?? 0
+            let (bufferState, bufferSeconds) = await MainActor.run {
+                let state = provider.previousBufferingMonitor?.bufferState ?? .unknown
+                let seconds = provider.previousBufferingMonitor?.bufferSeconds ?? 0
+                return (state, seconds)
             }
             
             Logger.preloading.debug("🎯 MONITOR STATE: Prev video buffer from monitor: \(bufferSeconds)s, state=\(bufferState.description)")
             
-            // Update buffer state
+            // Publish buffer state update
             await MainActor.run {
-                self.updatePrevBufferState(bufferState)
+                self.publishBufferStateUpdate()
             }
             
             // Check if buffer is ready - require 2 consecutive ready states to avoid false positives
@@ -166,81 +168,4 @@ extension TransitionPreloadManager {
         }
     }
     
-    /// Monitor buffer status for previous video asynchronously
-    private func monitorPreviousVideoBuffer(player: AVPlayer, videoId: String, preloadStart: Double) async {
-        Logger.caching.info("🔄 PRELOAD PREV: Starting buffer monitoring for \(videoId)")
-        let playerItem = player.currentItem
-        
-        // Start monitoring buffer status
-        while !Task.isCancelled && playerItem == player.currentItem {
-            // Get buffer ranges to check actual loaded time
-            let loadedTimeRanges = playerItem?.loadedTimeRanges ?? []
-
-            // Calculate buffered duration ahead of current playback position
-            var bufferedSeconds = 0.0
-            if let currentTime = playerItem?.currentTime(), !loadedTimeRanges.isEmpty {
-                // Find how much is buffered ahead of current position
-                for range in loadedTimeRanges {
-                    let timeRange = range.timeRangeValue
-                    let rangeStart = CMTimeGetSeconds(timeRange.start)
-                    let rangeEnd = CMTimeGetSeconds(CMTimeAdd(timeRange.start, timeRange.duration))
-                    let current = CMTimeGetSeconds(currentTime)
-                    
-                    // Check if current time is within this range
-                    if current >= rangeStart && current <= rangeEnd {
-                        // Return the amount buffered ahead
-                        bufferedSeconds = rangeEnd - current
-                        break
-                    }
-                    
-                    // Check if this range is ahead of current time
-                    if rangeStart > current {
-                        bufferedSeconds = rangeEnd - current
-                        break
-                    }
-                }
-            }
-
-            // Calculate buffer state
-            let bufferState = BufferState.from(seconds: bufferedSeconds)
-            
-            // Log the buffer calculation for debugging
-            Logger.preloading.debug("🧮 BUFFER CALC: Prev video buffered=\(bufferedSeconds)s, state=\(bufferState.rawValue)")
-            
-            // Update buffer state
-            await MainActor.run {
-                self.updatePrevBufferState(bufferState)
-            }
-            
-            // Check if buffer is ready - requires both conditions:
-            // 1. isPlaybackLikelyToKeepUp is true
-            // 2. Buffer state is ready (sufficient, good, or excellent)
-            if playerItem?.isPlaybackLikelyToKeepUp == true && bufferState.isReady {
-                // Capture values for logging
-                let currentBufferedSeconds = bufferedSeconds
-                let currentBufferState = bufferState
-                
-                await MainActor.run {
-                    Logger.caching.info("✅ PRELOAD PREV: Buffer ready for \(videoId) (buffered: \(currentBufferedSeconds)s, state: \(currentBufferState.description))")
-                    // Update dot to be solid green by setting ready flag
-                    prevVideoReady = true
-                }
-
-                // Calculate and log preloading completion time
-                let preloadEndTime = CFAbsoluteTimeGetCurrent()
-                let preloadDuration = preloadEndTime - preloadStart
-                Logger.caching.info("⏱️ TIMING: Previous video preloading completed in \(preloadDuration.formatted(.number.precision(.fractionLength(3)))) seconds")
-
-                // No need to signal preloading complete - our phased approach handles this
-                // Phase 2 (general caching) automatically starts after this method completes
-                Logger.caching.info("✅ PHASE 1B COMPLETE: Previous video successfully preloaded")
-
-                break
-            }
-
-            // If not ready yet, wait briefly and check again
-            Logger.caching.debug("⏳ PRELOAD PREV: Buffer not yet ready for \(videoId) (buffered: \(bufferedSeconds)s, state: \(bufferState.description))")
-            try? await Task.sleep(for: .seconds(0.5))
-        }
-    }
 }


### PR DESCRIPTION
## Summary

This PR fixes issue #89 by making BufferingMonitor the single source of truth for all buffer state management in the app. It removes the duplicate buffer tracking system that existed in TransitionPreloadManager.

## Changes Made

- 🔥 **Removed duplicate buffer monitoring methods** (`monitorNextVideoBuffer()` and `monitorPreviousVideoBuffer()`) that performed their own buffer calculations
- 🔥 **Removed buffer state assumptions** from `nextVideoReady` and `prevVideoReady` setters that automatically set buffer states
- ♻️ **Updated TransitionPreloadManager** to query BufferingMonitor instances directly instead of maintaining its own buffer state
- 🏗️ **Maintained backward compatibility** while ensuring BufferingMonitor is the only component calculating buffer state

## Technical Details

### Files Modified
- `TransitionPreloadManager.swift` - Removed buffer state assumptions from ready flags
- `TransitionPreloadManager+NextVideo.swift` - Removed duplicate buffer monitoring method
- `TransitionPreloadManager+PreviousVideo.swift` - Removed duplicate buffer monitoring method  
- `TransitionPreloadManager+Caching.swift` - Added provider reference for accessing BufferingMonitor
- `VideoTransitionManager+NextTransition.swift` - Updated buffer state access with proper actor isolation
- `VideoTransitionManager+PreviousTransition.swift` - Updated buffer state access with proper actor isolation

### Lines of Code
- **58 insertions(+), 205 deletions(-)**
- Net reduction of 147 lines by removing duplicate buffer calculation logic

## Testing

- ✅ Build completes successfully with no errors
- ⚠️ Existing test failures in PreloadingIndicatorManagerTests are unrelated to this change and appear to be pre-existing

## Fixes #89

🤖 Generated with [Claude Code](https://claude.ai/code)