### PR TITLE
fix: Restore swipe functionality broken by BufferingMonitor refactoring

### DIFF
--- a/LostArchiveTV/Services/TransitionPreloadManager+NextVideo.swift
+++ b/LostArchiveTV/Services/TransitionPreloadManager+NextVideo.swift
@@ -281,8 +281,8 @@ extension TransitionPreloadManager {
             
             Logger.preloading.debug("🎯 MONITOR STATE: Next video buffer from monitor: \(bufferSeconds)s, state=\(bufferState.description)")
             
-            // Update buffer state
-            self.updateNextBufferState(bufferState)
+            // Publish buffer state update (monitors are the source of truth)
+            self.publishBufferStateUpdate()
             
             // Check if buffer is ready - require 2 consecutive ready states to avoid false positives
             if bufferState.isReady {


### PR DESCRIPTION
## Summary
- Fixed broken swipe functionality that was introduced in PR #90
- BufferingMonitor is now truly the single source of truth for buffer state
- Removed stale member variables and unused update methods

## Problem
After merging PR #90 (commit ee8a3b0), users could no longer swipe between videos because:
- The `nextBufferState` and `prevBufferState` member variables were never updated
- `computeCombinedBufferState()` still read from these stale variables
- Buffer states remained stuck at `.unknown`, preventing `isReady` from returning true

## Solution
1. **Removed unused member variables** (`nextBufferState`, `prevBufferState`)
2. **Removed unused update methods** (`updateNextBufferState()`, `updatePrevBufferState()`)
3. **Updated `computeCombinedBufferState()`** to query BufferingMonitors directly via the provider
4. **Updated public accessors** to also query monitors directly

## Test Plan
- [x] Build succeeds without errors
- [ ] Swipe up to next video works when buffered
- [ ] Swipe down to previous video works when buffered
- [ ] Buffer state indicators show correct status
- [ ] No regression in video playback functionality

Fixes #91

🤖 Generated with [Claude Code](https://claude.ai/code)