### PR TITLE
Fix preset collections being overwritten when switching between presets

### DIFF
--- a/LostArchiveTV/ViewModels/HomeFeedSettingsViewModel.swift
+++ b/LostArchiveTV/ViewModels/HomeFeedSettingsViewModel.swift
@@ -216,9 +216,6 @@ class HomeFeedSettingsViewModel: ObservableObject {
             
             // No need to explicitly load identifiers as they're accessed directly from the preset now
         }
-        
-        // Notify of changes
-        saveSettings()
     }
     
     func createNewPreset(name: String) {

--- a/LostArchiveTV/Views/Components/HomeFeedSettingsSection.swift
+++ b/LostArchiveTV/Views/Components/HomeFeedSettingsSection.swift
@@ -67,7 +67,6 @@ struct HomeFeedSettingsSection: View {
                             useDefault = false
                             UserDefaults.standard.set(false, forKey: "UseDefaultCollections")
                             viewModel.useDefaultCollections = false
-                            viewModel.saveSettings()
                         }
                     }
                 } 


### PR DESCRIPTION
## Summary
- Fixes #106 where preset collections were being overwritten when switching between presets
- Removed unnecessary `saveSettings()` calls from both preset selection points
- Preset selection is now a read-only operation while creation/update/delete remain write operations

## Problem
When users switched between presets, the collections from the previously selected preset would incorrectly overwrite the newly selected preset's collections. This was a critical data loss bug making the preset feature unreliable.

## Root Cause
There were TWO places calling `saveSettings()` when selecting a preset:
1. In `HomeFeedSettingsViewModel.selectPreset(withId:)` 
2. In `HomeFeedSettingsSection` when tapping a preset

Both were saving the current UI state back to the preset, overwriting its original configuration.

## Solution
Removed both `saveSettings()` calls from preset selection code:
- `HomeFeedSettingsViewModel.swift`: Removed `saveSettings()` from `selectPreset(withId:)`
- `HomeFeedSettingsSection.swift`: Removed `saveSettings()` from preset tap handler

Now:
- **Preset selection**: Only loads data (no save)
- **Preset creation**: Still saves via `createNewPreset()`
- **Preset update/delete**: Still saves appropriately

This ensures preset selection is a read-only operation while maintaining save functionality where actually needed.

## Testing
- ✅ Build completes successfully with no errors
- ✅ Preset creation still works (has its own `saveSettings()` call)
- ✅ Preset switching no longer overwrites collections

🤖 Generated with [Claude Code](https://claude.ai/code)