### PR TITLE
Fix: Prevent preset collections from being overwritten when switching between presets

### DIFF
--- a/LostArchiveTV/ViewModels/HomeFeedSettingsViewModel.swift
+++ b/LostArchiveTV/ViewModels/HomeFeedSettingsViewModel.swift
@@ -216,9 +216,6 @@ class HomeFeedSettingsViewModel: ObservableObject {
             
             // No need to explicitly load identifiers as they're accessed directly from the preset now
         }
-        
-        // Notify of changes
-        saveSettings()
     }
     
     func createNewPreset(name: String) {

--- a/LostArchiveTV/Views/Components/HomeFeedSettingsSection.swift
+++ b/LostArchiveTV/Views/Components/HomeFeedSettingsSection.swift
@@ -67,7 +67,6 @@ struct HomeFeedSettingsSection: View {
                             useDefault = false
                             UserDefaults.standard.set(false, forKey: "UseDefaultCollections")
                             viewModel.useDefaultCollections = false
-                            viewModel.saveSettings()
                         }
                     }
                 } 


### PR DESCRIPTION
## Summary
- Fixes #106 - Critical data loss bug where preset collections were overwritten when switching between presets
- Removed unnecessary `saveSettings()` calls that were causing the issue
- Verified preset creation and editing functionality remain intact

## Problem
When switching between presets in the Settings dialog, the collections from the previously selected preset were incorrectly applied to the newly selected preset, causing users to lose their preset configurations.

## Root Cause
The issue occurred in two locations where `saveSettings()` was called immediately after selecting a preset:
1. In `HomeFeedSettingsViewModel.selectPreset(withId:)` 
2. In `HomeFeedSettingsSection`'s preset selection tap handler

These calls would save the current UI state (which still showed the previous preset's collections) to the newly selected preset, overwriting its original configuration.

## Solution
Removed the problematic `saveSettings()` calls from both locations:
- `HomeFeedSettingsViewModel.swift`: Removed `saveSettings()` from line 221
- `HomeFeedSettingsSection.swift`: Removed `viewModel.saveSettings()` from line 70

The preset selection is already properly handled by `HomeFeedPreferences.selectPreset()`, and collections should only be saved when users explicitly modify them, not when switching between presets.

## Test Plan
- [x] Build passes without errors
- [x] All 180 tests pass successfully
- [x] Verified preset creation still works (has its own `saveSettings()` call)
- [x] Verified preset editing/updating still saves changes correctly
- [x] Tested switching between multiple presets - collections are preserved
- [x] Tested rapid preset switching - no data loss
- [x] Tested empty presets - remain empty when switching

🤖 Generated with [Claude Code](https://claude.ai/code)