### PR TITLE
Fix: UI state doesn't properly sync when switching between presets in Settings

### DIFF
--- a/LostArchiveTV/Views/CollectionsView.swift
+++ b/LostArchiveTV/Views/CollectionsView.swift
@@ -101,5 +101,10 @@ struct CollectionsView: View {
         }
         .navigationTitle("Collections")
         .navigationBarTitleDisplayMode(.large)
+        .onAppear {
+            // Sync collections with the currently selected preset
+            // This ensures UI reflects correct state when navigating here
+            viewModel.syncCollectionsWithSelectedPreset()
+        }
     }
 }

--- a/LostArchiveTV/Views/Components/HomeFeedSettingsSection.swift
+++ b/LostArchiveTV/Views/Components/HomeFeedSettingsSection.swift
@@ -58,15 +58,9 @@ struct HomeFeedSettingsSection: View {
                     .contentShape(Rectangle())
                     .onTapGesture {
                         if !useDefault {
-                            // When selecting a preset, we need to do three things:
-                            // 1. Select the preset in the HomeFeedPreferences service
-                            HomeFeedPreferences.selectPreset(withId: preset.id)
-                            // 2. Update our view model and UI
-                            viewModel.loadPresets()
-                            // 3. Clear the useDefault flag to ensure we're using custom mode
-                            useDefault = false
-                            UserDefaults.standard.set(false, forKey: "UseDefaultCollections")
-                            viewModel.useDefaultCollections = false
+                            // Use viewModel method to handle preset selection
+                            // This ensures proper state management and synchronization
+                            viewModel.selectPreset(withId: preset.id)
                         }
                     }
                 } 


### PR DESCRIPTION
## Summary
- Fixed UI state synchronization issues when switching between presets
- Consolidated all preset selection logic to go through the view model
- Added automatic collection state refresh when navigating to Collections view

## Issue Reference
Fixes #109

## Problem
After switching between presets in the Settings dialog, the UI state wasn't properly synchronizing. While the underlying data was correctly saved (fixed in #106), the SwiftUI views showed stale or incorrect information, particularly in the Collections view.

## Solution

### 1. Added Collection Sync Method
- Created `syncCollectionsWithSelectedPreset()` method in `HomeFeedSettingsViewModel` to synchronize collection enabled states with the currently selected preset

### 2. Consolidated Preset Selection
- Updated `HomeFeedSettingsSection` to use `viewModel.selectPreset()` instead of directly calling service methods
- This ensures all state updates happen atomically through the view model

### 3. Updated selectPreset() Method
- Now handles all related state updates in one place:
  - Preset selection in HomeFeedPreferences
  - useDefaultCollections flag updates
  - UserDefaults synchronization
  - Collection state synchronization

### 4. Added Automatic Refresh
- Added `.onAppear` modifier to `CollectionsView` to refresh collection state when navigated to
- Ensures the UI always shows the correct state for the current preset

## Testing
- ✅ Build succeeds without errors
- ✅ Preset switching now immediately updates UI
- ✅ Collections view shows correct state without manual refresh
- ✅ Rapid preset switching works correctly
- ✅ State persists correctly after app restart

## Changes
- `HomeFeedSettingsViewModel.swift`: Added sync method and updated preset selection logic
- `HomeFeedSettingsSection.swift`: Consolidated preset selection through view model
- `CollectionsView.swift`: Added onAppear refresh

🤖 Generated with [Claude Code](https://claude.ai/code)