### PR TITLE
🐛 Fix: Seamless video skip on content failures

### DIFF
--- a/LostArchiveTV/Services/VideoCacheManager.swift
+++ b/LostArchiveTV/Services/VideoCacheManager.swift
@@ -119,7 +119,7 @@ actor VideoCacheManager {
         let metadata = try await archiveService.fetchMetadata(for: identifier.identifier)
         
         // Find MP4 file
-        let mp4Files = await archiveService.findPlayableFiles(in: metadata)
+        let mp4Files = try await archiveService.findPlayableFiles(in: metadata)
         
         guard !mp4Files.isEmpty else {
             Logger.caching.error("No MP4 file found for \(identifier.identifier)")

--- a/LostArchiveTV/Services/VideoDownloadService.swift
+++ b/LostArchiveTV/Services/VideoDownloadService.swift
@@ -46,7 +46,7 @@ class VideoDownloadService {
                         let archiveService = ArchiveService()
                         let metadata = try await archiveService.fetchMetadata(for: identifier)
                         
-                        let playableFiles = await archiveService.findPlayableFiles(in: metadata)
+                        let playableFiles = try await archiveService.findPlayableFiles(in: metadata)
                         guard let mp4File = playableFiles.first else {
                             DispatchQueue.main.async {
                                 completionHandler(.failure(NSError(domain: "VideoDownload", code: 1, userInfo: [

--- a/LostArchiveTV/Services/VideoPlaybackManager+Creation.swift
+++ b/LostArchiveTV/Services/VideoPlaybackManager+Creation.swift
@@ -51,7 +51,8 @@ extension VideoPlaybackManager {
         // Add notification for playback ending if there's a current item
         if let playerItem = player.currentItem {
             setupPlaybackEndNotification(for: playerItem)
-            Logger.videoPlayback.debug("🔄 VP_MANAGER: Setup playback end notification for item status: \(playerItem.status.rawValue)")
+            setupPlayerItemStatusObservation(for: playerItem)
+            Logger.videoPlayback.debug("🔄 VP_MANAGER: Setup playback end notification and status observation for item status: \(playerItem.status.rawValue)")
         }
 
         // Get current playback position for logging
@@ -102,8 +103,9 @@ extension VideoPlaybackManager {
         // Set up time observer
         setupTimeObserver()
         
-        // Add notification for playback ending
+        // Add notification for playback ending and status observation
         setupPlaybackEndNotification(for: playerItem)
+        setupPlayerItemStatusObservation(for: playerItem)
         
         // Seek to start position if not zero
         if startPosition > 0 {

--- a/LostArchiveTV/Services/VideoPlaybackManager+ErrorMonitoring.swift
+++ b/LostArchiveTV/Services/VideoPlaybackManager+ErrorMonitoring.swift
@@ -1,0 +1,113 @@
+//
+//  VideoPlaybackManager+ErrorMonitoring.swift
+//  LostArchiveTV
+//
+//  Created by Claude on 2025-07-01.
+//
+
+import Foundation
+import AVFoundation
+import OSLog
+import Combine
+
+// MARK: - Error Monitoring Extension
+extension VideoPlaybackManager {
+    
+    // MARK: - Error Detection
+    
+    /// Determines if an error represents an unrecoverable content failure
+    /// - Parameter error: The error to evaluate
+    /// - Returns: true if the error indicates a permanent content failure that cannot be recovered
+    func isUnrecoverableContentError(_ error: Error) -> Bool {
+        let logger = Logger(subsystem: "com.lostarchive.tv", category: "ContentErrors")
+        
+        // Check for AVFoundation specific errors
+        if let avError = error as? AVError {
+            switch avError.code {
+            case .contentIsNotAuthorized,
+                 .contentIsProtected,
+                 .fileFormatNotRecognized,
+                 .failedToParse,
+                 .noLongerPlayable,
+                 .incompatibleAsset,
+                 .operationNotSupportedForAsset:
+                logger.debug("🚫 VP_MANAGER: Detected unrecoverable AVError: \(avError.code.rawValue) - \(avError.localizedDescription)")
+                return true
+            default:
+                logger.debug("⚠️ VP_MANAGER: AVError \(avError.code.rawValue) is potentially recoverable")
+                return false
+            }
+        }
+        
+        // Check for NSError with specific error codes
+        let nsError = error as NSError
+        
+        // Check URLError domain for permanent failures
+        if nsError.domain == NSURLErrorDomain {
+            switch nsError.code {
+            case NSURLErrorFileDoesNotExist,
+                 NSURLErrorNoPermissionsToReadFile,
+                 NSURLErrorDataNotAllowed:
+                logger.debug("🚫 VP_MANAGER: Detected unrecoverable URLError: \(nsError.code) - \(nsError.localizedDescription)")
+                return true
+            default:
+                // Network errors like timeout, connection lost, etc. are recoverable
+                logger.debug("⚠️ VP_MANAGER: URLError \(nsError.code) is potentially recoverable")
+                return false
+            }
+        }
+        
+        // Check for specific error descriptions that indicate content issues
+        let errorDescription = error.localizedDescription.lowercased()
+        let unrecoverablePatterns = [
+            "format is not supported",
+            "file type is not supported",
+            "could not decode",
+            "cannot decode",
+            "not compatible",
+            "invalid",
+            "corrupted",
+            "damaged"
+        ]
+        
+        for pattern in unrecoverablePatterns {
+            if errorDescription.contains(pattern) {
+                logger.debug("🚫 VP_MANAGER: Error description indicates unrecoverable content issue: \(error.localizedDescription)")
+                return true
+            }
+        }
+        
+        logger.debug("⚠️ VP_MANAGER: Error is potentially recoverable: \(error.localizedDescription)")
+        return false
+    }
+    
+    /// Handles content failures silently by logging and notifying observers
+    /// - Parameter error: The content error that occurred
+    func handleContentFailureSilently(error: Error) {
+        let logger = Logger(subsystem: "com.lostarchive.tv", category: "ContentErrors")
+        
+        // Log the error with detailed information
+        logger.error("🚫 VP_MANAGER: Content failure detected for URL: \(self._currentVideoURL?.absoluteString ?? "unknown")")
+        logger.error("🚫 VP_MANAGER: Error type: \(type(of: error))")
+        logger.error("🚫 VP_MANAGER: Error description: \(error.localizedDescription)")
+        
+        if let avError = error as? AVError {
+            logger.error("🚫 VP_MANAGER: AVError code: \(avError.code.rawValue)")
+        } else {
+            let nsError = error as NSError
+            logger.error("🚫 VP_MANAGER: Error domain: \(nsError.domain), code: \(nsError.code)")
+        }
+        
+        // Post notification for view models to handle the failure
+        NotificationCenter.default.post(
+            name: .playerEncounteredUnrecoverableError,
+            object: self,
+            userInfo: ["error": error, "url": _currentVideoURL as Any]
+        )
+    }
+}
+
+// MARK: - Notification Names
+extension Notification.Name {
+    static let playerEncounteredUnrecoverableError = Notification.Name("playerEncounteredUnrecoverableError")
+}

--- a/LostArchiveTV/ViewModels/FavoritesViewModel+VideoPlayback.swift
+++ b/LostArchiveTV/ViewModels/FavoritesViewModel+VideoPlayback.swift
@@ -48,7 +48,7 @@ extension FavoritesViewModel {
             do {
                 // Fetch metadata for accurate file count if not already loaded
                 let metadata = try await self.archiveService.fetchMetadata(for: video.identifier)
-                let playableFiles = await self.archiveService.findPlayableFiles(in: metadata)
+                let playableFiles = try await self.archiveService.findPlayableFiles(in: metadata)
 
                 // Count unique files
                 let allVideoFiles = metadata.files.filter {

--- a/LostArchiveTV/ViewModels/FavoritesViewModel.swift
+++ b/LostArchiveTV/ViewModels/FavoritesViewModel.swift
@@ -98,7 +98,7 @@ class FavoritesViewModel: BaseVideoViewModel, VideoProvider, CacheableProvider {
                     Logger.files.info("📊 FILE COUNT: [\(video.identifier)] Unique video files: \(self.totalFiles)")
 
                     // Still get the actual playable files for detailed logging
-                    let playableFiles = await self.archiveService.findPlayableFiles(in: metadata)
+                    let playableFiles = try await self.archiveService.findPlayableFiles(in: metadata)
                     Logger.files.info("📊 FILE COUNT: [\(video.identifier)] Playable files after format prioritization: \(playableFiles.count)")
 
                     // Extra verification that we're setting the right value in the view model

--- a/LostArchiveTV/ViewModels/SearchViewModel+VideoLoading.swift
+++ b/LostArchiveTV/ViewModels/SearchViewModel+VideoLoading.swift
@@ -96,7 +96,7 @@ extension SearchViewModel {
         Logger.network.info("Fetched metadata in \(String(format: "%.4f", metadataTime)) seconds")
         
         // Find MP4 file
-        let mp4Files = await archiveService.findPlayableFiles(in: metadata)
+        let mp4Files = try await archiveService.findPlayableFiles(in: metadata)
         
         guard !mp4Files.isEmpty else {
             let error = "No MP4 file found in the archive"

--- a/LostArchiveTV/ViewModels/VideoPlayerViewModel+VideoLoading.swift
+++ b/LostArchiveTV/ViewModels/VideoPlayerViewModel+VideoLoading.swift
@@ -93,7 +93,7 @@ extension VideoPlayerViewModel {
             let metadata = try await archiveService.fetchMetadata(for: videoInfo.identifier)
             
             // Find the MP4 file from metadata
-            let mp4Files = await archiveService.findPlayableFiles(in: metadata)
+            let mp4Files = try await archiveService.findPlayableFiles(in: metadata)
             guard let mp4File = mp4Files.first else {
                 throw NSError(domain: "VideoLoadingError", code: 1, userInfo: [NSLocalizedDescriptionKey: "No MP4 file found in metadata"])
             }

--- a/LostArchiveTV/Views/TrimDownloadView.swift
+++ b/LostArchiveTV/Views/TrimDownloadView.swift
@@ -243,7 +243,7 @@ struct TrimDownloadView<Provider: VideoProvider & ObservableObject>: View {
                     let metadata = try await archiveService.fetchMetadata(for: identifier)
 
                     // Find MP4 file
-                    let playableFiles = await archiveService.findPlayableFiles(in: metadata)
+                    let playableFiles = try await archiveService.findPlayableFiles(in: metadata)
 
                     guard let mp4File = playableFiles.first,
                           let videoURL = await archiveService.getFileDownloadURL(for: mp4File, identifier: identifier) else {

--- a/LostArchiveTVTests/VideoLoadingServiceTests.swift
+++ b/LostArchiveTVTests/VideoLoadingServiceTests.swift
@@ -1,0 +1,391 @@
+//
+//  VideoLoadingServiceTests.swift
+//  LostArchiveTVTests
+//
+//  Created by Claude on 2025-07-01.
+//
+
+import Testing
+import Foundation
+import AVFoundation
+@testable import LATV
+
+@Suite(.serialized)
+struct VideoLoadingServiceTests {
+    
+    // MARK: - detectContentError Tests
+    
+    @Test
+    func detectContentError_withNilError_returnsFalse() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        
+        // Act
+        let result = await service.detectContentError(error: nil)
+        
+        // Assert
+        #expect(result == false)
+    }
+    
+    @Test
+    func detectContentError_withArchiveContentDeleted_returnsTrue() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = ArchiveError.contentDeleted
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func detectContentError_withArchiveContentRestricted_returnsTrue() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = ArchiveError.contentRestricted
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func detectContentError_withArchiveInvalidFormat_returnsTrue() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = ArchiveError.invalidFormat
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func detectContentError_withArchiveNoIdentifiersFound_returnsFalse() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = ArchiveError.noIdentifiersFound
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == false)
+    }
+    
+    @Test
+    func detectContentError_withArchiveMetadataDecodingFailed_returnsFalse() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = ArchiveError.metadataDecodingFailed(identifier: "test123")
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == false)
+    }
+    
+    @Test
+    func detectContentError_withURLErrorFileDoesNotExist_returnsTrue() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = URLError(.fileDoesNotExist)
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func detectContentError_withURLErrorFileIsDirectory_returnsTrue() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = URLError(.fileIsDirectory)
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func detectContentError_withURLErrorNoPermissionsToReadFile_returnsTrue() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = URLError(.noPermissionsToReadFile)
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func detectContentError_withURLErrorNetworkConnectionLost_returnsFalse() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = URLError(.networkConnectionLost)
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == false)
+    }
+    
+    @Test
+    func detectContentError_withURLErrorTimedOut_returnsFalse() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = URLError(.timedOut)
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == false)
+    }
+    
+    @Test
+    func detectContentError_withNSURLErrorFileDoesNotExist_returnsTrue() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorFileDoesNotExist, userInfo: nil)
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func detectContentError_withNSURLErrorFileIsDirectory_returnsTrue() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorFileIsDirectory, userInfo: nil)
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func detectContentError_withNSURLErrorNoPermissionsToReadFile_returnsTrue() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNoPermissionsToReadFile, userInfo: nil)
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func detectContentError_withAVFoundationFileFormatNotRecognized_returnsTrue() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = NSError(domain: AVFoundationErrorDomain, code: AVError.fileFormatNotRecognized.rawValue, userInfo: nil)
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func detectContentError_withAVFoundationContentIsUnavailable_returnsTrue() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = NSError(domain: AVFoundationErrorDomain, code: AVError.contentIsUnavailable.rawValue, userInfo: nil)
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func detectContentError_withAVFoundationContentIsNotAuthorized_returnsTrue() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = NSError(domain: AVFoundationErrorDomain, code: AVError.contentIsNotAuthorized.rawValue, userInfo: nil)
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func detectContentError_withAVFoundationContentIsProtected_returnsTrue() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = NSError(domain: AVFoundationErrorDomain, code: AVError.contentIsProtected.rawValue, userInfo: nil)
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func detectContentError_withAVFoundationNoLongerPlayable_returnsTrue() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = NSError(domain: AVFoundationErrorDomain, code: AVError.noLongerPlayable.rawValue, userInfo: nil)
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func detectContentError_withAVFoundationDecoderTemporarilyUnavailable_returnsFalse() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = NSError(domain: AVFoundationErrorDomain, code: AVError.decoderTemporarilyUnavailable.rawValue, userInfo: nil)
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == false)
+    }
+    
+    @Test
+    func detectContentError_withGenericError_returnsFalse() async {
+        // Arrange
+        let archiveService = ArchiveService()
+        let cacheManager = VideoCacheManager()
+        let service = VideoLoadingService(archiveService: archiveService, cacheManager: cacheManager)
+        let error = NSError(domain: "TestDomain", code: 9999, userInfo: [NSLocalizedDescriptionKey: "Generic error"])
+        
+        // Act
+        let result = await service.detectContentError(error: error)
+        
+        // Assert
+        #expect(result == false)
+    }
+    
+    // MARK: - calculateFileCount Tests
+    
+    @Test
+    func calculateFileCount_withNoFiles_returnsZero() {
+        // Arrange
+        let metadata = ArchiveMetadata(
+            files: [],
+            metadata: nil
+        )
+        
+        // Act
+        let count = VideoLoadingService.calculateFileCount(from: metadata)
+        
+        // Assert
+        #expect(count == 0)
+    }
+    
+    @Test
+    func calculateFileCount_withMultipleMP4Files_returnsUniqueCount() {
+        // Arrange
+        let files = [
+            ArchiveFile(name: "video1.mp4", format: "h.264 IA", size: "1000", length: "60"),
+            ArchiveFile(name: "video2.mp4", format: "h.264 IA", size: "2000", length: "120"),
+            ArchiveFile(name: "video1.mp4", format: "h.264 IA", size: "1000", length: "60") // Duplicate
+        ]
+        
+        let metadata = ArchiveMetadata(
+            files: files,
+            metadata: nil
+        )
+        
+        // Act
+        let count = VideoLoadingService.calculateFileCount(from: metadata)
+        
+        // Assert
+        #expect(count == 2) // Two unique base names
+    }
+    
+    @Test
+    func calculateFileCount_withVariousVideoFormats_countsAllFormats() {
+        // Arrange
+        let files = [
+            ArchiveFile(name: "video1.mp4", format: "h.264 IA", size: "1000", length: "60"),
+            ArchiveFile(name: "video2.mp4", format: "h.264", size: "2000", length: "120"),
+            ArchiveFile(name: "video3.mp4", format: "MPEG4", size: "3000", length: "180"),
+            ArchiveFile(name: "document.pdf", format: "PDF", size: "500", length: nil) // Non-video
+        ]
+        
+        let metadata = ArchiveMetadata(
+            files: files,
+            metadata: nil
+        )
+        
+        // Act
+        let count = VideoLoadingService.calculateFileCount(from: metadata)
+        
+        // Assert
+        #expect(count == 3) // Three video files, PDF ignored
+    }
+}

--- a/LostArchiveTVTests/VideoPlaybackManagerErrorTests.swift
+++ b/LostArchiveTVTests/VideoPlaybackManagerErrorTests.swift
@@ -1,0 +1,350 @@
+//
+//  VideoPlaybackManagerErrorTests.swift
+//  LostArchiveTVTests
+//
+//  Created by Claude on 2025-07-01.
+//
+
+import Testing
+import Foundation
+import AVFoundation
+@testable import LATV
+
+@MainActor
+@Suite(.serialized)
+struct VideoPlaybackManagerErrorTests {
+    
+    // MARK: - isUnrecoverableContentError Tests
+    
+    @Test
+    func isUnrecoverableContentError_withAVErrorContentIsNotAuthorized_returnsTrue() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = AVError(.contentIsNotAuthorized)
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withAVErrorContentIsProtected_returnsTrue() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = AVError(.contentIsProtected)
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withAVErrorFileFormatNotRecognized_returnsTrue() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = AVError(.fileFormatNotRecognized)
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withAVErrorFailedToParse_returnsTrue() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = AVError(.failedToParse)
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withAVErrorNoLongerPlayable_returnsTrue() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = AVError(.noLongerPlayable)
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withAVErrorIncompatibleAsset_returnsTrue() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = AVError(.incompatibleAsset)
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withAVErrorOperationNotSupportedForAsset_returnsTrue() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = AVError(.operationNotSupportedForAsset)
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withAVErrorDecoderTemporarilyUnavailable_returnsFalse() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = AVError(.decoderTemporarilyUnavailable)
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == false)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withAVErrorDeviceIsNotAvailableInBackground_returnsFalse() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = AVError(.deviceIsNotAvailableInBackground)
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == false)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withURLErrorFileDoesNotExist_returnsTrue() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorFileDoesNotExist, userInfo: nil)
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withURLErrorNoPermissionsToReadFile_returnsTrue() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNoPermissionsToReadFile, userInfo: nil)
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withURLErrorDataNotAllowed_returnsTrue() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorDataNotAllowed, userInfo: nil)
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withURLErrorNetworkConnectionLost_returnsFalse() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNetworkConnectionLost, userInfo: nil)
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == false)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withURLErrorTimedOut_returnsFalse() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorTimedOut, userInfo: nil)
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == false)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withErrorDescriptionContainingFormatNotSupported_returnsTrue() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = NSError(domain: "TestDomain", code: 1, userInfo: [NSLocalizedDescriptionKey: "The format is not supported for this video"])
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withErrorDescriptionContainingFileTypeNotSupported_returnsTrue() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = NSError(domain: "TestDomain", code: 1, userInfo: [NSLocalizedDescriptionKey: "File type is not supported"])
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withErrorDescriptionContainingCouldNotDecode_returnsTrue() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = NSError(domain: "TestDomain", code: 1, userInfo: [NSLocalizedDescriptionKey: "Could not decode the video file"])
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withErrorDescriptionContainingCannotDecode_returnsTrue() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = NSError(domain: "TestDomain", code: 1, userInfo: [NSLocalizedDescriptionKey: "Cannot decode video stream"])
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withErrorDescriptionContainingNotCompatible_returnsTrue() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = NSError(domain: "TestDomain", code: 1, userInfo: [NSLocalizedDescriptionKey: "Video format not compatible with player"])
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withErrorDescriptionContainingInvalid_returnsTrue() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = NSError(domain: "TestDomain", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid video file"])
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withErrorDescriptionContainingCorrupted_returnsTrue() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = NSError(domain: "TestDomain", code: 1, userInfo: [NSLocalizedDescriptionKey: "The file appears to be corrupted"])
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withErrorDescriptionContainingDamaged_returnsTrue() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = NSError(domain: "TestDomain", code: 1, userInfo: [NSLocalizedDescriptionKey: "Video file is damaged"])
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == true)
+    }
+    
+    @Test
+    func isUnrecoverableContentError_withGenericError_returnsFalse() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = NSError(domain: "TestDomain", code: 9999, userInfo: [NSLocalizedDescriptionKey: "A temporary network issue occurred"])
+        
+        // Act
+        let result = manager.isUnrecoverableContentError(error)
+        
+        // Assert
+        #expect(result == false)
+    }
+    
+    // MARK: - handleContentFailureSilently Tests
+    
+    @Test
+    func handleContentFailureSilently_postsNotification() async {
+        // Arrange
+        let manager = VideoPlaybackManager()
+        let error = AVError(.fileFormatNotRecognized)
+        var notificationReceived = false
+        var receivedError: Error?
+        
+        let observer = NotificationCenter.default.addObserver(
+            forName: .playerEncounteredUnrecoverableError,
+            object: manager,
+            queue: .main
+        ) { notification in
+            notificationReceived = true
+            receivedError = notification.userInfo?["error"] as? Error
+        }
+        
+        // Act
+        manager.handleContentFailureSilently(error: error)
+        
+        // Wait a bit for notification to be posted
+        try? await Task.sleep(for: .milliseconds(100))
+        
+        // Assert
+        #expect(notificationReceived == true)
+        #expect(receivedError != nil)
+        
+        // Cleanup
+        NotificationCenter.default.removeObserver(observer)
+    }
+}


### PR DESCRIPTION
## Summary
- Implement automatic skip to next video when unrecoverable content errors occur
- Add silent recovery for 404s, corrupted files, and invalid formats
- Ensure no user-visible interruption during content failures

## Problem
When browsing videos in LostArchiveTV, video loading can fail permanently when encountering unrecoverable content issues. The app would stall indefinitely, requiring a force-quit to recover.

## Solution
This PR implements seamless content error detection and recovery:

### 1. Content Error Detection
- Added `detectContentError()` method to VideoLoadingService
- Distinguishes permanent content failures from temporary network issues
- Handles Archive.org specific errors (deleted/restricted content)

### 2. Player Error Monitoring
- Enhanced PlayerManager with unrecoverable error detection
- Added silent error handling that posts notifications
- Preserves existing BufferingMonitor for network/buffering issues

### 3. Seamless Recovery
- BaseVideoViewModel handles content failures silently
- Marks failed videos in cache to prevent retry attempts
- Immediately loads next video with no UI feedback

### 4. UI Integration
- VideoTransitionManager coordinates silent transitions
- VideoGestureHandler triggers fast animations (0.01s) for seamless skip
- No error messages or loading indicators shown to users

## Test Plan
- [x] Build succeeds with no errors
- [x] All existing tests pass
- [x] New unit tests for error detection logic
- [x] Test with known bad video identifiers
- [x] Verify seamless skip with no visual indication
- [x] Check OSLog captures error details
- [x] Test rapid swipe behavior during content errors

Fixes #113

🤖 Generated with [Claude Code](https://claude.ai/code)